### PR TITLE
Prevent from going to top of page when clicking on "Report"

### DIFF
--- a/SpamReporter.user.js
+++ b/SpamReporter.user.js
@@ -76,8 +76,8 @@
         
         
         var report = function(e) {
-			e.preventDefault();
-			
+            e.preventDefault();
+
             if(!confirm('Do you really want to report this post?')) {
                 return false;
             }

--- a/SpamReporter.user.js
+++ b/SpamReporter.user.js
@@ -75,7 +75,9 @@
         };
         
         
-        var report = function() {
+        var report = function(e) {
+			e.preventDefault();
+			
             if(!confirm('Do you really want to report this post?')) {
                 return false;
             }


### PR DESCRIPTION
After reporting a post, the user is automatically redirected to the top of the page (because of the # anchor). This patch prevents that action from happening.
