### PR TITLE
handle broken cv-pls chat message

### DIFF
--- a/CVRequestArchiver.user.js
+++ b/CVRequestArchiver.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         CV Request Archiver
 // @namespace    https://github.com/Tiny-Giant/
-// @version      2.0.0.3
+// @version      2.0.0.4
 // @description  Scans the chat transcript and checks all cv requests for status, then moves the closed ones.
 // @author       @TinyGiant @rene
 // @include      /https?:\/\/chat(\.meta)?\.stack(overflow|exchange).com\/rooms\/.*/
@@ -289,8 +289,11 @@ function CVRequestArchiver(info){
         if (!isreq) return false;
         var matches = message.match(/http.*?(?:q[^\/]*|posts)\/(\d+)/g);
         var posts = [];
-        for(var k in Object.keys(matches)) {
-            posts.push(/(?:q[^\/]*|posts)\/(\d+)/.exec(matches[k])[1]);
+        // matches will be null if an user screws up the formatting
+        if (matches !== null) {
+            for(var k in Object.keys(matches)) {
+                posts.push(/(?:q[^\/]*|posts)\/(\d+)/.exec(matches[k])[1]);
+            }
         }
         for(var l in posts) requests.push({ msg: event.message_id, post: posts[l], time: event.time_stamp });
     }


### PR DESCRIPTION
if a cv-pls message doesn't have a valid link in it a null reference exception is raised, this patch fixes that at the latest possible moment. Maybe such messages should be filtered out earlier, but hey, regex..

http://chat.stackoverflow.com/transcript/41570?m=28798284#28798284
