### PR TITLE
MTR2 show -Voted, fix snippets, & show spinner after filter until ready

### DIFF
--- a/MagicTagReview2.user.js
+++ b/MagicTagReview2.user.js
@@ -305,6 +305,9 @@ document.addEventListener('DOMContentLoaded', async _ => {
                     text-align: center;
                     width: 50px;
                 }
+                .review-didCloseVote {
+                    color: red;
+                }
             `;
             const HTML = `
                 <div class="review-bar-container">
@@ -669,17 +672,29 @@ document.addEventListener('DOMContentLoaded', async _ => {
             StackExchange.using('inlineEditing', function () {
                 StackExchange.ready(function () {
                     StackExchange.question.init(initInfo);
+                    var title = document.querySelector('.review-title');
+                    var didCloseVote = title.parentNode.querySelector('.review-didCloseVoteFull');
+                    if (document.querySelector('a[title^="You voted to close"]')) {
+                        if(didCloseVote) {
+                            didCloseVote.style.display = '';
+                        } else {
+                            if(title) {
+                                title.insertAdjacentHTML('afterend','<span class="review-didCloseVoteFull"> - <span class="review-didCloseVote">Voted</span></span>');
+                            }
+                        }
+                    } else {
+                        if(didCloseVote) {
+                            didCloseVote.style.display = 'none';
+                        }
+                    }
                     StackExchange.comments.loadAll($('.question'));
-                    //Remove the <script> this was loaded in.
-                    document.getElementById(questionInitId).remove();
+                    StackExchange.using("snippets", function () {
+                        StackExchange.snippets.initSnippetRenderer();
+                        StackExchange.snippets.redraw();
+                        //Remove the <script> this was loaded in.
+                        document.getElementById(questionInitId).remove();
+                    });
                 });
-            });
-        };
-
-        const inPageInitSnippetRenderer = snippetInitId => {
-            StackExchange.using("snippets", function () {
-                StackExchange.snippets.initSnippetRenderer();
-                document.getElementById(snippetInitId).remove();
             });
         };
 
@@ -691,10 +706,6 @@ document.addEventListener('DOMContentLoaded', async _ => {
             if (post) {
                 nodes.title.href      = 'http://stackoverflow.com/q/' + post.question_id;
                 nodes.title.innerHTML = post.title;
-
-                if (document.querySelector('a[title^="You voted to close"]')) {
-                    nodes.title.textContent += ' - <span style="color:red">Voted</span>';
-                }
 
                 nodes.question.innerHTML = await fetchQuestion(post);
 
@@ -755,8 +766,6 @@ document.addEventListener('DOMContentLoaded', async _ => {
                 
                 nodes.information.innerHTML = '';
                 nodes.information.insertAdjacentHTML('beforeend', buildInfo(post));
-                const snippetInitId = 'magicTag2-initSnippetRenderer-' + performance.now();
-                executeInPage(inPageInitSnippetRenderer, true, snippetInitId , snippetInitId);
                 nodes.task.style.display="";
             }
             

--- a/MagicTagReview2.user.js
+++ b/MagicTagReview2.user.js
@@ -519,15 +519,15 @@ document.addEventListener('DOMContentLoaded', async _ => {
 
         /** Start Functions **/
 
-        const reset = (q, f, c) => {
-            if(q) {
+        const reset = (queue, filters, current, keepProgresText) => {
+            if(queue) {
                 queue         = [];
                 question_list = [];
                 store.queue         = '[]';
                 store.question_list = '[]';
                 nodes.indicator_quota.textContent = '';
             }
-            if(f) {
+            if(filters) {
                 nodes.tagged           .value = '';
                 nodes.sort             .value = '';
                 nodes.order            .value = '';
@@ -554,7 +554,7 @@ document.addEventListener('DOMContentLoaded', async _ => {
                 nodes.includestags     .value = '';
                 nodes.excludestags     .value = '';
             }
-            if(c) {
+            if(current) {
                 store.current = 0;
             }
 
@@ -568,7 +568,9 @@ document.addEventListener('DOMContentLoaded', async _ => {
             nodes.stop.disabled         = true;
             nodes.prev.disabled         = true;
             nodes.next.disabled         = true;
-            nodes.indicator_progress.textContent  = '';
+            if(!keepProgresText) {
+                nodes.indicator_progress.textContent  = '';
+            }
         };
 
         const retrieve = _ => new Promise(async (resolve, reject) => {
@@ -691,6 +693,8 @@ document.addEventListener('DOMContentLoaded', async _ => {
                     StackExchange.using("snippets", function () {
                         StackExchange.snippets.initSnippetRenderer();
                         StackExchange.snippets.redraw();
+                        document.querySelector('.review-spinner').style.display = 'none';
+                        document.querySelector('.review-indicator .progress').textContent = '';
                         //Remove the <script> this was loaded in.
                         document.getElementById(questionInitId).remove();
                     });
@@ -699,7 +703,7 @@ document.addEventListener('DOMContentLoaded', async _ => {
         };
 
         const display = current => new Promise(async (resolve, reject) => {
-            reset();
+            reset(0,0,0,1);
 
             const post = queue[current];
 
@@ -882,10 +886,14 @@ document.addEventListener('DOMContentLoaded', async _ => {
                 resolve(queue);
             });
             
-            nodes.spinner.hide();
+            //Don't hide the spinner here due to Chrome/Tampermonkey's issue with GM Storage being expensive.
+            //nodes.spinner.hide();
             nodes.applyFilters.disabled = false;
             nodes.stopFilter.disabled = true;
             nodes.indicator_progress.textContent = '';
+            if(GM_info.script.author) {
+                nodes.indicator_progress.textContent = 'Waiting for data to store (Tampermonkey issue)';
+            }
             stop = false;
             
             console.log(queue.map(post => ' - https://stackoverflow.com/q/' + post.question_id).join('\n'));


### PR DESCRIPTION
1. Bug fix: code to show " - Voted" when the user had close-voted was executed at the wrong time.
2. Snippets required some adjustment to show while paging through questions.
3. After filtering, show the spinner until the question is ready.
  On Chrome, Tampermonkey's excessively expensive GM store operation can cause a multi-second delay after the filtering is done. This is confusing to the user if the spinner is hidden immediately after filtering is complete. Unfortunately, asynchronously storing the data just moves the time when the tab's UI becomes unresponsive, which is still confusing to the user.
    
    Other than fixing Tampermonkey, or finding some other workaround, an actual solution to this would be to store less data. The possibility that comes to mind is to store in the queue the indexes at which the questions can be found in the question list, not a copy of each entire question. This should dramatically reduce the amount of data stored for the queue.