### PR TITLE
MTR2 add auto-next after vote and Skip Voted, Closed, Deleted & performance improvements

### DIFF
--- a/MagicTagReview2.user.js
+++ b/MagicTagReview2.user.js
@@ -785,8 +785,8 @@ document.addEventListener('DOMContentLoaded', async _ => {
 
         /** Start Functions **/
 
-        const reset = (queue, filters, current, keepProgresText) => {
-            if(queue) {
+        const reset = (theQueue, filters, current, keepProgresText) => {
+            if(theQueue) {
                 queue         = [];
                 question_list = [];
                 store.queue         = '[]';
@@ -974,7 +974,15 @@ document.addEventListener('DOMContentLoaded', async _ => {
         const display = current => new Promise(async (resolve, reject) => {
             reset(0,0,0,1);
 
-            const post = queue[current];
+            current = +current;
+            //Don't overrun the bounds of the queue.
+            if(!current || current < 0) {
+                current = 0;
+            }
+            if(current > queue.length - 1) {
+                current = queue.length - 1;
+            }
+            const post = question_list[queue[current]];
 
             if (post) {
                 nodes.title.href      = 'http://stackoverflow.com/q/' + post.question_id;
@@ -1043,7 +1051,7 @@ document.addEventListener('DOMContentLoaded', async _ => {
             }
             
             nodes.prev.disabled = !queue.length || current < 1;
-            nodes.next.disabled = !queue.length || current === queue.length - 1;
+            nodes.next.disabled = !queue.length || current >= queue.length - 1;
             nodes.position.value = queue.length ? `${current + 1}/${queue.length}` : '0/0';
         });
         
@@ -1145,7 +1153,7 @@ document.addEventListener('DOMContentLoaded', async _ => {
             //Function to get the results for every active filter on a question.
             const filterQuestion = question => filterList.reduce((allResults, [filterKey, filter]) => Object.assign(allResults, {[filterKey]: filter(question)}), {});
             
-            const queue = await new Promise(async resolve => {
+            const newQueue = await new Promise(async resolve => {
                 const filteredQueue = [];
 
                 const isset = {
@@ -1191,7 +1199,7 @@ document.addEventListener('DOMContentLoaded', async _ => {
                     };
                     
                     //Add the question to the queue, if it matches at least one primary filter. Add the primary filter results to any accepted question.
-                    if(Object.values(primaryFilters).some(primeFilter => primeFilter)) filteredQueue.push(Object.assign(question, {primaryFilters}));
+                    if(Object.values(primaryFilters).some(primeFilter => primeFilter)) filteredQueue.push(index);
                 }
                 
                 resolve(filteredQueue);
@@ -1207,13 +1215,13 @@ document.addEventListener('DOMContentLoaded', async _ => {
             }
             stop = false;
             
-            console.log(queue.map(post => ' - https://stackoverflow.com/q/' + post.question_id).join('\n'));
+            console.log(newQueue.map(index => ' - https://stackoverflow.com/q/' + question_list[index].question_id).join('\n'));
 
             var performElapsedSeconds = (performance.now() - performStart)/1000;
             var questionsPerSecond = question_list.length/performElapsedSeconds;
             console.log('Filtered', question_list.length.toLocaleString(), 'questions in', performElapsedSeconds.toLocaleString(), 'seconds at a rate of', questionsPerSecond.toLocaleString(), 'questions/s.');
             
-            return queue;
+            return newQueue;
         };
 
         /** End Functions **/

--- a/MagicTagReview2.user.js
+++ b/MagicTagReview2.user.js
@@ -859,7 +859,7 @@ document.addEventListener('DOMContentLoaded', async _ => {
 
             let page = 1, totalpages = 1, url;
         
-            while(page <= totalpages && result.quota_remaining !== 0 && !result.backoff && stop === false) {
+            while(page <= totalpages && result.quota_remaining !== 0 && stop === false) {
                 nodes.indicator_progress.textContent = `Retrieving question list (page ${page} of ${(totalpages||1)})`;
                 nodes.indicator_quota   .textContent = `API Quota remaining: ${result.quota_remaining}`;
                 url = `${location.protocol}//api.stackexchange.com/2.2/questions?${[
@@ -885,7 +885,10 @@ document.addEventListener('DOMContentLoaded', async _ => {
                 
                 question_list.push(...result.items);
                 
-                if(result.backoff) console.log('Backoff: ' + result.backoff);
+                if(result.backoff) {
+                    console.log('Backoff: ' + result.backoff);
+                    await delay(result.backoff * 1000);
+                }
             }
             store.question_list = JSON.stringify(question_list);
             
@@ -1044,7 +1047,7 @@ document.addEventListener('DOMContentLoaded', async _ => {
             nodes.position.value = queue.length ? `${current + 1}/${queue.length}` : '0/0';
         });
         
-        const delay = _ => new Promise(resolve => setTimeout(resolve));
+        const delay = milliseconds => new Promise(resolve => setTimeout(resolve, (milliseconds ? milliseconds : 0)));
         
         const filterQuestions = async question_list => {
             var performStart = performance.now();

--- a/MagicTagReview2.user.js
+++ b/MagicTagReview2.user.js
@@ -5,7 +5,7 @@
 // @description  Custom review queue for tag oriented reviewing with the ability to filter by close votes and delete votes
 // @author       @TinyGiant
 // @contributor  @Makyen
-// @include      /^https?:\/\/\w*.?stackoverflow\.com\/review*/
+// @include      /^https?:\/\/(?:\w*\.)?stackoverflow\.com\/review(?:/?|\/MagicTagReview)(?:\?.*)?$/
 // @grant        GM_getValue
 // @grant        GM_setValue
 // @grant        GM_listValues

--- a/MagicTagReview2.user.js
+++ b/MagicTagReview2.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Magic™ Tag Review 2
 // @namespace    http://github.com/Tiny-Giant
-// @version      1.0.1.2
+// @version      1.0.2.0
 // @description  Custom review queue for tag oriented reviewing with the ability to filter by close votes and delete votes
 // @author       @TinyGiant
 // @contributor  @Makyen

--- a/MagicTagReview2.user.js
+++ b/MagicTagReview2.user.js
@@ -8,6 +8,8 @@
 // @include      /^https?:\/\/\w*.?stackoverflow\.com\/review*/
 // @grant        GM_getValue
 // @grant        GM_setValue
+// @grant        GM_listValues
+// @grant        GM_deleteValue
 // @grant        GM_addValueChangeListener
 // @run-at       document-start
 // ==/UserScript==
@@ -172,20 +174,90 @@ const inPageAddXHRListener = listen => {
 });*/
 executeInPage(inPageAddXHRListener, true, 'magicTagReview-addXHRListener');
 
-/** @Proxy store - Wraps GM_(set/get)value with a prefix to prevent interference with other scripts */
+//LZ-String 1.4.4
+// Copyright (c) 2013 Pieroxy <pieroxy@pieroxy.net>
+// This work is free. You can redistribute it and/or modify it
+// under the terms of the WTFPL, Version 2
+// For more information see LICENSE.txt or http://www.wtfpl.net/
+//
+// For more information, the home page:
+// http://pieroxy.net/blog/pages/lz-string/testing.html
+//
+// LZ-based compression algorithm, version 1.4.4
+// From: https://github.com/pieroxy/lz-string/blob/master/libs/lz-string.min.js
+var LZString=function(){function o(o,r){if(!t[o]){t[o]={};for(var n=0;n<o.length;n++)t[o][o.charAt(n)]=n}return t[o][r]}var r=String.fromCharCode,n="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",e="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-$",t={},i={compressToBase64:function(o){if(null==o)return"";var r=i._compress(o,6,function(o){return n.charAt(o)});switch(r.length%4){default:case 0:return r;case 1:return r+"===";case 2:return r+"==";case 3:return r+"="}},decompressFromBase64:function(r){return null==r?"":""==r?null:i._decompress(r.length,32,function(e){return o(n,r.charAt(e))})},compressToUTF16:function(o){return null==o?"":i._compress(o,15,function(o){return r(o+32)})+" "},decompressFromUTF16:function(o){return null==o?"":""==o?null:i._decompress(o.length,16384,function(r){return o.charCodeAt(r)-32})},compressToUint8Array:function(o){for(var r=i.compress(o),n=new Uint8Array(2*r.length),e=0,t=r.length;t>e;e++){var s=r.charCodeAt(e);n[2*e]=s>>>8,n[2*e+1]=s%256}return n},decompressFromUint8Array:function(o){if(null===o||void 0===o)return i.decompress(o);for(var n=new Array(o.length/2),e=0,t=n.length;t>e;e++)n[e]=256*o[2*e]+o[2*e+1];var s=[];return n.forEach(function(o){s.push(r(o))}),i.decompress(s.join(""))},compressToEncodedURIComponent:function(o){return null==o?"":i._compress(o,6,function(o){return e.charAt(o)})},decompressFromEncodedURIComponent:function(r){return null==r?"":""==r?null:(r=r.replace(/ /g,"+"),i._decompress(r.length,32,function(n){return o(e,r.charAt(n))}))},compress:function(o){return i._compress(o,16,function(o){return r(o)})},_compress:function(o,r,n){if(null==o)return"";var e,t,i,s={},p={},u="",c="",a="",l=2,f=3,h=2,d=[],m=0,v=0;for(i=0;i<o.length;i+=1)if(u=o.charAt(i),Object.prototype.hasOwnProperty.call(s,u)||(s[u]=f++,p[u]=!0),c=a+u,Object.prototype.hasOwnProperty.call(s,c))a=c;else{if(Object.prototype.hasOwnProperty.call(p,a)){if(a.charCodeAt(0)<256){for(e=0;h>e;e++)m<<=1,v==r-1?(v=0,d.push(n(m)),m=0):v++;for(t=a.charCodeAt(0),e=0;8>e;e++)m=m<<1|1&t,v==r-1?(v=0,d.push(n(m)),m=0):v++,t>>=1}else{for(t=1,e=0;h>e;e++)m=m<<1|t,v==r-1?(v=0,d.push(n(m)),m=0):v++,t=0;for(t=a.charCodeAt(0),e=0;16>e;e++)m=m<<1|1&t,v==r-1?(v=0,d.push(n(m)),m=0):v++,t>>=1}l--,0==l&&(l=Math.pow(2,h),h++),delete p[a]}else for(t=s[a],e=0;h>e;e++)m=m<<1|1&t,v==r-1?(v=0,d.push(n(m)),m=0):v++,t>>=1;l--,0==l&&(l=Math.pow(2,h),h++),s[c]=f++,a=String(u)}if(""!==a){if(Object.prototype.hasOwnProperty.call(p,a)){if(a.charCodeAt(0)<256){for(e=0;h>e;e++)m<<=1,v==r-1?(v=0,d.push(n(m)),m=0):v++;for(t=a.charCodeAt(0),e=0;8>e;e++)m=m<<1|1&t,v==r-1?(v=0,d.push(n(m)),m=0):v++,t>>=1}else{for(t=1,e=0;h>e;e++)m=m<<1|t,v==r-1?(v=0,d.push(n(m)),m=0):v++,t=0;for(t=a.charCodeAt(0),e=0;16>e;e++)m=m<<1|1&t,v==r-1?(v=0,d.push(n(m)),m=0):v++,t>>=1}l--,0==l&&(l=Math.pow(2,h),h++),delete p[a]}else for(t=s[a],e=0;h>e;e++)m=m<<1|1&t,v==r-1?(v=0,d.push(n(m)),m=0):v++,t>>=1;l--,0==l&&(l=Math.pow(2,h),h++)}for(t=2,e=0;h>e;e++)m=m<<1|1&t,v==r-1?(v=0,d.push(n(m)),m=0):v++,t>>=1;for(;;){if(m<<=1,v==r-1){d.push(n(m));break}v++}return d.join("")},decompress:function(o){return null==o?"":""==o?null:i._decompress(o.length,32768,function(r){return o.charCodeAt(r)})},_decompress:function(o,n,e){var t,i,s,p,u,c,a,l,f=[],h=4,d=4,m=3,v="",w=[],A={val:e(0),position:n,index:1};for(i=0;3>i;i+=1)f[i]=i;for(p=0,c=Math.pow(2,2),a=1;a!=c;)u=A.val&A.position,A.position>>=1,0==A.position&&(A.position=n,A.val=e(A.index++)),p|=(u>0?1:0)*a,a<<=1;switch(t=p){case 0:for(p=0,c=Math.pow(2,8),a=1;a!=c;)u=A.val&A.position,A.position>>=1,0==A.position&&(A.position=n,A.val=e(A.index++)),p|=(u>0?1:0)*a,a<<=1;l=r(p);break;case 1:for(p=0,c=Math.pow(2,16),a=1;a!=c;)u=A.val&A.position,A.position>>=1,0==A.position&&(A.position=n,A.val=e(A.index++)),p|=(u>0?1:0)*a,a<<=1;l=r(p);break;case 2:return""}for(f[3]=l,s=l,w.push(l);;){if(A.index>o)return"";for(p=0,c=Math.pow(2,m),a=1;a!=c;)u=A.val&A.position,A.position>>=1,0==A.position&&(A.position=n,A.val=e(A.index++)),p|=(u>0?1:0)*a,a<<=1;switch(l=p){case 0:for(p=0,c=Math.pow(2,8),a=1;a!=c;)u=A.val&A.position,A.position>>=1,0==A.position&&(A.position=n,A.val=e(A.index++)),p|=(u>0?1:0)*a,a<<=1;f[d++]=r(p),l=d-1,h--;break;case 1:for(p=0,c=Math.pow(2,16),a=1;a!=c;)u=A.val&A.position,A.position>>=1,0==A.position&&(A.position=n,A.val=e(A.index++)),p|=(u>0?1:0)*a,a<<=1;f[d++]=r(p),l=d-1,h--;break;case 2:return w.join("")}if(0==h&&(h=Math.pow(2,m),m++),f[l])v=f[l];else{if(l!==d)return null;v=s+s.charAt(0)}w.push(v),f[d++]=s+v.charAt(0),h--,s=v,0==h&&(h=Math.pow(2,m),m++)}}};return i}();"function"==typeof define&&define.amd?define(function(){return LZString}):"undefined"!=typeof module&&null!=module&&(module.exports=LZString);
+
+
+/** @Proxy store - Wraps GM_(set/get)value */
 //Use an in-script cache for what's being stored to GM storage. A side effect is that updates in other tabs
 //  are NOT seen cross-tab once the value is first read from storage. This provides semi-independance across
 //  tabs.
 var storageCache = {};
+try {
+    storageCache = JSON.parse(localStorage['MagicTagReview-storeageCache']);
+} catch(e) {
+}
+var storageCacheSeparate = {};
+var storageCacheTimeout=0;
+const storageSeparateList = ['queue', 'question_list', 'current'];
 const store = new Proxy({}, {
-    get: (t, k) => (typeof storageCache[k] === 'undefined' ? storageCache[k] = GM_getValue(`MagicTagReview-${ k }`) : storageCache[k]),
+    get: (target, key) => {
+        if (storageSeparateList.indexOf(key) > -1) {
+            if(key === 'current') {
+                var current = +localStorage['MagicTagReview-' + key];
+                return current ? current : 0;
+            } else {
+                if(typeof storageCacheSeparate[key] === 'undefined') {
+                    const lzString = GM_getValue(`${key}-LZString`);
+                    const uncompressed = LZString.decompressFromBase64(lzString);
+                    storageCacheSeparate[key] = uncompressed;
+                }
+                return storageCacheSeparate[key];
+            }
+        } else {
+            return storageCache[key];
+        }
+    },
     //Immediately update the cache and GM storage.
-    //Saving the data to GM storage asynchronously doesn't solve the problem.
-    //Storing large amounts of data to GM storage in Chrome/Tampermonkey is expensive. It will freeze the tab and
+    //Saving the data to GM storage asynchronously doesn't solve the problem of long times to store data.
+    //Storing large amounts of data or multiple values to GM storage in Chrome/Tampermonkey is expensive. It will freeze the tab and
     //  all Tampermonkey UI tabs (i.e. ones in the background context) for several seconds (it may affect all Tampermonkey
     //  operations (at least in the background context, which will probably affect loading scripts in new pages).
-    //  This is not the case in Firefox/Tampermonkey or Firefox/Greasemonkey.
-    set: (t, k, v) => (storageCache[k] = v, GM_setValue(`MagicTagReview-${ k }`, storageCache[k]), true)
+    //  Thus, only the queue and question_list are stored in GM storage. Everything else is stored in localStorage.
+    set: (target, key, value) => {
+        if (storageSeparateList.indexOf(key) > -1) {
+            if(key === 'current') {
+                localStorage['MagicTagReview-' + key] = value;
+            } else {
+                storageCacheSeparate[key] = value;
+                const compressed = LZString.compressToBase64(value);
+                const uncompressed = LZString.decompressFromBase64(compressed);
+                GM_setValue(`${key}-LZString`, compressed);
+                const lzString = GM_getValue(`${key}-LZString`);
+                const uncompressed2 = LZString.decompressFromBase64(lzString);
+            }
+        } else {
+            storageCache[key] = value;
+            //Don't stall execution for storing the chache (this doesn't actually help Chrome/Tampermonkey).
+            clearTimeout(storageCacheTimeout);
+            storageCacheTimeout = setTimeout(_ => {
+                localStorage['MagicTagReview-storeageCache'] = JSON.stringify(storageCache);
+            }, 0);
+        }
+        return true;
+    }
+});
+
+//Clean-up from earlier released version of the script/Transfer data from original GM_setValue keys to storageCache.
+//We need to clear localStorage *and* GM_storage
+var gmValuesList = GM_listValues();
+gmValuesList.forEach(key => {
+    if(key.indexOf('MagicTagReview-') === 0) {
+        var mainKey = key.replace(/^MagicTagReview-/,'');
+        var value = GM_getValue(key);
+        store[mainKey] = value;
+        GM_deleteValue(key);
+    }
 });
 
 /*Get values from in-page window properties (e.g. window.StackExchange...)

--- a/MagicTagReview2.user.js
+++ b/MagicTagReview2.user.js
@@ -47,7 +47,18 @@ const executeInPage = function(functionToRunInPage, leaveInPage, id) {
                 });
                 asText += ']';
             } else if (obj === null) {
-                asText +='null';
+                asText += 'null';
+            //undefined
+            } else if (obj === void(0)) {
+                asText += 'void(0)';
+            //Special cases for Number
+            } else if (Number.isNaN(obj)) {
+                asText += 'Number.NaN';
+            } else if (obj === 1/0) {
+                asText += '1/0';
+            } else if (obj === 1/-0) {
+                asText += '1/-0';
+            //function
             } else if (obj instanceof RegExp || typeof obj === 'function') {
                 asText +=  obj.toString();
             } else if (obj instanceof Date) {
@@ -83,7 +94,7 @@ const executeInPage = function(functionToRunInPage, leaveInPage, id) {
     (document.head || document.documentElement).appendChild(newScript);
     if(!leaveInPage) {
         //Synchronous scripts are executed immediately and can be immediately removed.
-        //Scripts with asynchronous functionality of any type must remain in the page until all complete.
+        //Scripts with asynchronous functionality *may* need to remain in the page until complete.
         document.head.removeChild(newScript);
     }
     return newScript;

--- a/MagicTagReview2.user.js
+++ b/MagicTagReview2.user.js
@@ -1206,13 +1206,17 @@ document.addEventListener('DOMContentLoaded', async _ => {
             });
             
             //Don't hide the spinner here due to Chrome/Tampermonkey's issue with GM Storage being expensive.
-            //nodes.spinner.hide();
+            //Unless the queue is empty
+            if (newQueue.length === 0) {
+                nodes.spinner.hide();
+            } else {
+                if(GM_info.script.author) {
+                    nodes.indicator_progress.textContent = 'Waiting for data to store (Tampermonkey issue)';
+                }
+            }
             nodes.applyFilters.disabled = false;
             nodes.stopFilter.disabled = true;
             nodes.indicator_progress.textContent = '';
-            if(GM_info.script.author) {
-                nodes.indicator_progress.textContent = 'Waiting for data to store (Tampermonkey issue)';
-            }
             stop = false;
             
             console.log(newQueue.map(index => ' - https://stackoverflow.com/q/' + question_list[index].question_id).join('\n'));


### PR DESCRIPTION
* Add checkbox so the user can choose to automatically move to the next/previous question after voting.
* Add checkboxes for the user to select to auto-skip questions which they have voted on, are closed, or deleted.
* Performance improvements, so there isn't as long of a lag between the end of filtering and displaying the new question, particularly on Chrome.
  * Improve storage performance: only store selected items (e.g. the `question_list` in GM storage (which is where the performance issues are).
  * Change the `queue` to being a list of indexes instead of the full questions.
* Bug fix: hide the spinner after the filter results in no questions to display.
* Improve `executeInPage()`
* Enhance `getPageValue()`/`inPageReplyWithPageValue()`
* Don't abort upon receiving a backoff, just delay for the required time.
