### PR TITLE
Adjusted control location due to SO banner

### DIFF
--- a/StickyVoteControls.user.js
+++ b/StickyVoteControls.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Sticky vote controls
 // @namespace    http://github.com/TinyGiant/
-// @version      1.0.0.4
+// @version      1.0.0.5
 // @description  Makes the vote controls sticky
 // @author       @TinyGiant
 // @include      /^https?:\/\/(?!chat)\w*.?(stackexchange.com|stackoverflow.com|serverfault.com|superuser.com|askubuntu.com|stackapps.com|mathoverflow.net)\/.*/
@@ -16,7 +16,7 @@ document.body.insertAdjacentHTML("beforeend", `
         .question .vote,
         .answer .vote {
            position: sticky;
-           top: 0px;
+           top: 50px;
         }
     </style>
 `);


### PR DESCRIPTION
The Stack Overflow banner covers up the Upvote arrow. This fix addresses that and lowers the control by 50px